### PR TITLE
[cli] Add the help screen to the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,13 @@ with the current line highlighted.
 You can move the current line,
 or traverse the git history of the current line.
 
-Following commands are available:
-* **Enter**: Traverse to one older commit of the commit at the current line.
+Please see the help by pressing the `h` key
+for the full commands and their key bindings.
+Major commands are:
+* **h**: Show the help.
+* **q**: Quit the program.
+* **s**: Show the commit at the current line.
+* **c**: Copy the hash of the current line commit to the clipboard.
+* **Enter**: Traverse to the parent commit of the commit at the current line.
 * **Backspace**: Undo the last **Enter** key.
 * **Up**/**Down**: Move the current line to the previous/next commit.
-* **Home**/**End**/**PgUp**/**PgDown**: Move the current line.
-* **Number + Enter**: Go to the line.
-* **c**: Copy the hash of the current commit to the clipboard.
-* **q**: Quit the session.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -98,6 +98,18 @@ impl Cli {
                     terminal_raw_mode.reset();
                     Command::wait_for_any_key("Press any key to continue...")?;
                 }
+                Command::Help => {
+                    execute!(
+                        out,
+                        terminal::Clear(terminal::ClearType::All),
+                        cursor::MoveTo(0, 0),
+                    )?;
+                    renderer.invalidate_render();
+                    let mut terminal_raw_mode = TerminalRawModeScope::new(false)?;
+                    key_map.print_help();
+                    terminal_raw_mode.reset();
+                    Command::wait_for_any_key("Press any key to continue...")?;
+                }
                 Command::Repaint => renderer.invalidate_render(),
                 Command::Resize(columns, rows) => renderer.set_view_size((columns, rows - 1)),
                 Command::Quit => break,

--- a/src/command.rs
+++ b/src/command.rs
@@ -19,6 +19,7 @@ pub enum Command {
     Show,
     Repaint,
     Resize(u16, u16),
+    Help,
     Quit,
 }
 
@@ -72,7 +73,9 @@ impl Command {
                 out,
                 cursor::MoveTo(1, row),
                 style::SetForegroundColor(style::Color::DarkGrey),
-                style::Print("Enter=drill down, BS=back, q(uit), s(how commit), c(opy SHA1)"),
+                style::Print(
+                    "Enter=drill down, BS=back, q(uit), h(elp), s(how commit), c(opy SHA1)"
+                ),
                 style::ResetColor,
                 cursor::MoveTo(0, row),
                 style::Print(format!(":"))


### PR DESCRIPTION
Pressing the `h` key now shows a help message with the available commands.

Fixes #1.
