### PR TITLE
[cli] Add 'd' key to show the current file only

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Major commands are:
 * **h**: Show the help.
 * **q**: Quit the program.
 * **s**: Show the commit at the current line.
+* **d**: Show the current file of the commit at the current line.
 * **c**: Copy the hash of the current line commit to the clipboard.
 * **Enter**: Traverse to the parent commit of the commit at the current line.
 * **Backspace**: Undo the last **Enter** key.

--- a/src/blame_renderer.rs
+++ b/src/blame_renderer.rs
@@ -227,9 +227,16 @@ impl BlameRenderer {
         self.set_commit_id_core(commit_id, path, Some(line_index))
     }
 
-    pub fn show_current_line_commit(&mut self) -> anyhow::Result<()> {
+    pub fn show_current_line_commit(&mut self, current_file_only: bool) -> anyhow::Result<()> {
         let commit_id = self.current_line_commit_id();
-        self.git.show(commit_id)?;
+        self.git.show(
+            commit_id,
+            if current_file_only {
+                Some(self.content.path())
+            } else {
+                None
+            },
+        )?;
         self.invalidate_render();
         Ok(())
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -93,9 +93,9 @@ impl Cli {
                         message: "Copied to clipboard".to_string(),
                     };
                 }
-                Command::Show => {
+                Command::ShowCommit | Command::ShowDiff => {
                     let mut terminal_raw_mode = TerminalRawModeScope::new(false)?;
-                    renderer.show_current_line_commit()?;
+                    renderer.show_current_line_commit(command == Command::ShowDiff)?;
                     terminal_raw_mode.reset();
                     Command::wait_for_any_key("Press any key to continue...")?;
                 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -16,7 +16,8 @@ pub enum Command {
     Newer,
     LineNumber(usize),
     Copy,
-    Show,
+    ShowCommit,
+    ShowDiff,
     Repaint,
     Resize(u16, u16),
     Help,
@@ -73,9 +74,7 @@ impl Command {
                 out,
                 cursor::MoveTo(1, row),
                 style::SetForegroundColor(style::Color::DarkGrey),
-                style::Print(
-                    "Enter=drill down, BS=back, q(uit), h(elp), s(how commit), c(opy SHA1)"
-                ),
+                style::Print("h(elp), q(uit), Enter=parent, s(how), d(iff)"),
                 style::ResetColor,
                 cursor::MoveTo(0, row),
                 style::Print(format!(":"))

--- a/src/command_key_map.rs
+++ b/src/command_key_map.rs
@@ -72,8 +72,9 @@ impl CommandKeyMap {
     fn create_hash_map() ->HashMap<(KeyCode, KeyModifiers), Command> {
         HashMap::from([
             ((KeyCode::Char('c'), KeyModifiers::NONE), Command::Copy),
+            ((KeyCode::Char('d'), KeyModifiers::NONE), Command::ShowDiff),
             ((KeyCode::Char('h'), KeyModifiers::NONE), Command::Help),
-            ((KeyCode::Char('s'), KeyModifiers::NONE), Command::Show),
+            ((KeyCode::Char('s'), KeyModifiers::NONE), Command::ShowCommit),
             ((KeyCode::Char('q'), KeyModifiers::NONE), Command::Quit),
 
             // `vi`, `emacs`, or `less`-like key bindings.
@@ -106,15 +107,16 @@ impl CommandKeyMap {
             ("Show this help.", Command::Help),
             ("Quit the program.", Command::Quit),
 
-            ("#COMMITS", Command::Show),
-            ("Show the current line commit.", Command::Show),
+            ("#COMMITS", Command::ShowCommit),
+            ("Show the current line commit.", Command::ShowCommit),
+            ("Show the current file of the current line commit.", Command::ShowDiff),
             ("Copy the current line commit ID to clipboard.", Command::Copy),
 
-            ("#TRAVERSING TREES", Command::Show),
+            ("#TRAVERSING TREES", Command::Older),
             ("Show the parent tree of the current line commit.", Command::Older),
             ("Back to the last tree.", Command::Newer),
 
-            ("#MOVING", Command::Show),
+            ("#MOVING", Command::NextDiff),
             ("Move to the next diff.", Command::NextDiff),
             ("Move to the previous diff.", Command::PrevDiff),
             ("Move to the next page.", Command::NextPage),

--- a/src/git_tools.rs
+++ b/src/git_tools.rs
@@ -72,10 +72,13 @@ impl GitTools {
         revwalk.next().transpose()
     }
 
-    pub fn show(&self, commit_id: Oid) -> anyhow::Result<()> {
+    pub fn show(&self, commit_id: Oid, path: Option<&Path>) -> anyhow::Result<()> {
         let mut command = std::process::Command::new("git");
         command.current_dir(self.root_path());
         command.arg("show").arg(commit_id.to_string());
+        if let Some(path) = path {
+            command.arg("--").arg(path);
+        }
         let mut child = command.spawn()?;
         child.wait()?;
         Ok(())


### PR DESCRIPTION
While the `s` key runs `git show <commit>`, the `d` key runs
`git show <commit> -- <file>` to show the current file.
