### PR TITLE
[internal] Cleanup `Cli`

### DIFF
--- a/hooks/precommit.sh
+++ b/hooks/precommit.sh
@@ -2,7 +2,7 @@
 set -e
 (
   set -x
-  cargo test --all-targets --all-features
+  cargo test --all-features
 )
 if [[ "$1" == '-n' ]]; then
   set -x

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,6 @@ fn main() -> anyhow::Result<()> {
 
     let args: Vec<String> = env::args().collect();
     let path = PathBuf::from(&args[1]);
-    let mut cli: Cli = Cli::new(&path)?;
+    let mut cli: Cli = Cli::new(&path);
     cli.run()
 }


### PR DESCRIPTION
* Changed `new()` to return `Cli` instead of `Result<Cli>`.
* Removed `--all-targets` from `precommit.sh` as it disables doc-tests.
