### PR TITLE
internal: Add `FileCommits`

### DIFF
--- a/src/blame/file_commits.rs
+++ b/src/blame/file_commits.rs
@@ -1,0 +1,144 @@
+use std::collections::HashMap;
+use std::ops::{Deref, Index, Range, RangeFrom};
+use std::slice;
+
+use super::FileCommit;
+
+/// A collection of `FileCommit` objects, providing efficient lookup by OID.
+#[derive(Debug, Default)]
+pub struct FileCommits {
+    items: Vec<FileCommit>,
+    index_map: HashMap<git2::Oid, usize>,
+}
+
+impl FileCommits {
+    /// Creates a new, empty `FileCommits` collection.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds a `FileCommit` to the collection.
+    ///
+    /// The `FileCommit`'s internal index will be updated to its position in this collection.
+    pub fn push(&mut self, mut commit: FileCommit) {
+        let index = self.items.len();
+        commit.set_index(index); // Update the commit's own index
+        self.index_map.insert(commit.commit_id(), index);
+        self.items.push(commit);
+    }
+
+    /// Returns the number of commits in the collection.
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// Returns `true` if the collection contains no commits.
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    /// Returns a reference to the `FileCommit` at the given index, or `None` if the index is out of bounds.
+    pub fn get(&self, index: usize) -> Option<&FileCommit> {
+        self.items.get(index)
+    }
+
+    /// Returns the index of the `FileCommit` with the given `Oid`, or `None` if not found.
+    fn index_from_commit_id_opt(&self, commit_id: git2::Oid) -> Option<usize> {
+        if commit_id.is_zero() {
+            if self.items.is_empty() {
+                return Some(0);
+            }
+            return None;
+        }
+        self.index_map.get(&commit_id).copied()
+    }
+
+    pub fn index_from_commit_id(&self, commit_id: git2::Oid) -> anyhow::Result<usize> {
+        self.index_from_commit_id_opt(commit_id)
+            .ok_or_else(|| anyhow::anyhow!("Commit {commit_id:?} not found"))
+    }
+
+    /// Returns a reference to the `FileCommit` with the given `Oid`, or `None` if not found.
+    fn get_by_commit_id_opt(&self, commit_id: git2::Oid) -> Option<&FileCommit> {
+        self.index_from_commit_id_opt(commit_id)
+            .and_then(|index| self.items.get(index))
+    }
+
+    pub fn get_by_commit_id(&self, commit_id: git2::Oid) -> anyhow::Result<&FileCommit> {
+        self.get_by_commit_id_opt(commit_id)
+            .ok_or_else(|| anyhow::anyhow!("Commit {commit_id:?} not found"))
+    }
+
+    /// Returns an iterator over the commits in the collection.
+    pub fn iter(&self) -> slice::Iter<'_, FileCommit> {
+        self.items.iter()
+    }
+
+    /// Returns a reference to the first `FileCommit` in the collection, or `None` if it's empty.
+    pub fn first(&self) -> Option<&FileCommit> {
+        self.items.first()
+    }
+
+    /// Returns a slice containing all commits.
+    pub fn as_slice(&self) -> &[FileCommit] {
+        self.items.as_slice()
+    }
+}
+
+/// Allows `&FileCommits` to be automatically dereferenced to `&[FileCommit]`.
+impl Deref for FileCommits {
+    type Target = [FileCommit];
+
+    fn deref(&self) -> &Self::Target {
+        &self.items
+    }
+}
+
+/// Allows indexing `FileCommits` by `usize` to get a `FileCommit`.
+///
+/// # Panics
+///
+/// Panics if `index` is out of bounds.
+impl Index<usize> for FileCommits {
+    type Output = FileCommit;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.items[index]
+    }
+}
+
+/// Allows indexing `FileCommits` by `Range<usize>` to get a slice `&[FileCommit]`.
+///
+/// # Panics
+///
+/// Panics if the range is out of bounds.
+impl Index<Range<usize>> for FileCommits {
+    type Output = [FileCommit];
+
+    fn index(&self, range: Range<usize>) -> &Self::Output {
+        &self.items[range]
+    }
+}
+
+/// Allows indexing `FileCommits` by `RangeFrom<usize>` (e.g., `start..`) to get a slice `&[FileCommit]`.
+///
+/// # Panics
+///
+/// Panics if the start of the range is out of bounds.
+impl Index<RangeFrom<usize>> for FileCommits {
+    type Output = [FileCommit];
+
+    fn index(&self, range: RangeFrom<usize>) -> &Self::Output {
+        &self.items[range]
+    }
+}
+
+/// Allows iterating over `&FileCommits` to get `&FileCommit`.
+impl<'a> IntoIterator for &'a FileCommits {
+    type Item = &'a FileCommit;
+    type IntoIter = slice::Iter<'a, FileCommit>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.iter()
+    }
+}

--- a/src/blame/file_content.rs
+++ b/src/blame/file_content.rs
@@ -170,37 +170,42 @@ impl FileContent {
     }
 
     pub fn update_commits(&mut self, history: &FileHistory) -> anyhow::Result<()> {
+        let commits = history.commits();
         debug!(
             "update_commits: applied={}, #={}",
             self.applied_commits_len,
-            history.commits().len()
+            commits.len()
         );
-        assert!(history.commits().len() > self.applied_commits_len);
+        assert!(commits.len() > self.applied_commits_len);
         let start_time = std::time::Instant::now();
 
         if self.commit_id().is_zero() {
-            self.commit_id = history.commit(0).commit_id();
+            self.commit_id = commits[0].commit_id();
         }
         assert!(!self.commit_id().is_zero());
 
-        let mut first_index = self.applied_commits_len;
-        if first_index == 0 {
-            first_index = history.commit_index_from_commit_id(self.commit_id())?;
-        }
-        self.apply_commits(first_index, history)?;
+        let first_index = commits.index_from_commit_id(self.commit_id())?;
+        let skip = self.applied_commits_len.saturating_sub(first_index);
+        debug!(
+            "apply_commits: {first_index}..{} skip={skip}",
+            commits.len()
+        );
+        self.apply_commits(&commits[first_index..], skip)?;
         self.update_lines_after_apply();
-        self.applied_commits_len = history.commits().len();
+        self.applied_commits_len = commits.len();
         trace!("update_commits done, elapsed: {:?}", start_time.elapsed());
         Ok(())
     }
 
-    fn apply_commits(&mut self, first_index: usize, history: &FileHistory) -> anyhow::Result<()> {
-        let all_commits = history.commits();
-        debug!("apply_commits: {first_index}..{}", all_commits.len());
-        let commits = &all_commits[first_index..];
-        for i in 0..commits.len() {
+    fn apply_commits(&mut self, commits: &[FileCommit], skip: usize) -> anyhow::Result<()> {
+        for i in skip..commits.len() {
             let commit = &commits[i];
-            if i > 0 {
+            if i == 0 {
+                self.apply_diff_parts(commit.diff_parts(), commit)?;
+            } else {
+                // If i > 0, the line numbers in `commit.diff_parts().new`
+                // aren't the line numbers in `self.lines`. Map them to the line
+                // numbers of `self.lines`.
                 let mut adjusted_parts = commit.diff_parts().clone();
                 for j in (0..i).rev() {
                     let parts = &commits[j].diff_parts();
@@ -208,8 +213,6 @@ impl FileContent {
                     map.apply_to_parts(&mut adjusted_parts);
                 }
                 self.apply_diff_parts(&adjusted_parts, commit)?;
-            } else {
-                self.apply_diff_parts(commit.diff_parts(), commit)?;
             }
         }
         Ok(())

--- a/src/blame/line.rs
+++ b/src/blame/line.rs
@@ -79,7 +79,7 @@ impl Line {
         }
 
         let blame = if let Some(commit_id) = self.commit_id {
-            let commit = history.commit_from_commit_id(commit_id)?;
+            let commit = history.commits().get_by_commit_id(commit_id)?;
             match self.index_in_hunk {
                 0 => format!(
                     "#{} {}",

--- a/src/blame/mod.rs
+++ b/src/blame/mod.rs
@@ -1,6 +1,9 @@
 mod commit_iterator;
 pub use commit_iterator::*;
 
+mod file_commits;
+pub use file_commits::*;
+
 mod diff_part;
 pub use diff_part::*;
 

--- a/src/ui/blame_renderer.rs
+++ b/src/ui/blame_renderer.rs
@@ -198,7 +198,7 @@ impl BlameRenderer {
 
     pub fn set_commit_id_to_older_than_current_line(&mut self) -> anyhow::Result<()> {
         let commit_id = self.current_line_commit_id()?;
-        let commit_index = self.history.commit_index_from_commit_id(commit_id)?;
+        let commit_index = self.history.commits().index_from_commit_id(commit_id)?;
         let parent_commit_index = commit_index + 1;
         if parent_commit_index >= self.history.commits().len() {
             bail!("No commits before {commit_id}");
@@ -213,7 +213,7 @@ impl BlameRenderer {
         self.git().show(
             commit_id,
             if current_file_only {
-                let commit = self.history.commit_from_commit_id(commit_id)?;
+                let commit = self.history.commits().get_by_commit_id(commit_id)?;
                 Some(commit.path())
             } else {
                 None


### PR DESCRIPTION
This class not only wraps the `Vec<FileCommit>` but also has a
`HashMap` to make the lookup faster.

Also optimized `update_commits` by utilizing `FileCommits`.
