### PR TITLE
internal: Explicitly set `DiffFindOptions`

### DIFF
--- a/src/blame/file_commit.rs
+++ b/src/blame/file_commit.rs
@@ -100,7 +100,9 @@ impl FileCommit {
             Some(&tree),
             Some(&mut diff_options),
         )?;
-        diff.find_similar(None)?;
+        let mut diff_find_options = git2::DiffFindOptions::new();
+        diff_find_options.renames(true);
+        diff.find_similar(Some(&mut diff_find_options))?;
 
         let mut old_path: Option<PathBuf> = None;
         let mut context = DiffReadContext::default();


### PR DESCRIPTION
The [git_diff_find_options] document says:
> NOTE: if you don't explicitly set this, diff.renames could be set to false,
> resulting in git_diff_find_similar doing nothing.

[git_diff_find_options]: https://libgit2.org/docs/reference/main/diff/git_diff_find_options.html
