### PR TITLE
Switch diff retrieval from git2 to git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,6 +338,7 @@ dependencies = [
  "env_logger",
  "git2",
  "log",
+ "regex",
  "tempfile",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ crossterm = { version = "0.29.0", features = ["osc52"] }
 env_logger = "0.11.8"
 git2 = { version = "0.20.2", default-features = false }
 log = "0.4.27"
+regex = "1.11.1"
 
 [dev-dependencies]
 tempfile = "3.20.0"

--- a/src/blame/file_commit.rs
+++ b/src/blame/file_commit.rs
@@ -1,10 +1,21 @@
-use std::path::{Path, PathBuf};
+use std::{
+    io::BufReader,
+    path::{Path, PathBuf},
+};
 
 use log::*;
+use regex::Regex;
 
-use crate::extensions::GitTools;
+use crate::{blame::GitDiffLine, extensions::GitTools};
 
 use super::DiffPart;
+
+#[derive(Copy, Clone, Debug)]
+enum GitEngine {
+    Git,
+    Git2,
+}
+static mut DIFF_ENGINE: GitEngine = GitEngine::Git;
 
 #[derive(Debug)]
 pub struct FileCommit {
@@ -30,6 +41,14 @@ impl FileCommit {
             old_path: None,
             diff_parts: Vec::new(),
         }
+    }
+
+    fn git_engine() -> GitEngine {
+        unsafe { DIFF_ENGINE }
+    }
+
+    pub fn use_git2() {
+        unsafe { DIFF_ENGINE = GitEngine::Git2 }
     }
 
     pub fn commit_id(&self) -> git2::Oid {
@@ -70,11 +89,106 @@ impl FileCommit {
     }
 
     pub fn read(&mut self, git: &GitTools) -> anyhow::Result<()> {
-        trace!("read: {:?} {:?}", self.commit_id, self.path);
         assert!(self.path.is_relative());
         assert!(self.diff_parts.is_empty());
+        match Self::git_engine() {
+            GitEngine::Git => self.read_by_git(git),
+            GitEngine::Git2 => self.read_by_git2(git),
+        }?;
+        DiffPart::validate_ascending_parts(&self.diff_parts)
+    }
+
+    fn read_by_git(&mut self, git: &GitTools) -> anyhow::Result<()> {
         let start_time = std::time::Instant::now();
         let commit_id = self.commit_id;
+        debug!("read_by_git.start: {commit_id:?} {:?}", self.path);
+        let commit = git.repository().find_commit(commit_id)?;
+        self.set_commit(&commit);
+
+        let mut command = git.create_show_command(commit_id);
+        let mut child = command.stdout(std::process::Stdio::piped()).spawn()?;
+        let stdout = child.stdout.take().unwrap();
+        let reader = BufReader::new(stdout);
+        let mut buffer = GitDiffLine::new(reader);
+        let re_file = Regex::new(r"^diff --git a/(.+) b/(.+)$")?;
+        let re_hunk = Regex::new(r"^@@ -(\d+),(\d+) \+(\d+),(\d+) @@")?;
+
+        let path = self.path.to_str().unwrap();
+        let mut is_in_hunk = false;
+        let mut is_path_found = false;
+        let mut old_path: Option<PathBuf> = None;
+        let mut context = DiffReadContext::default();
+        while buffer.next_line()? {
+            let line = buffer.as_str();
+            if buffer.invalid_len() > 0 {
+                if line.is_empty() || line.starts_with("diff ") || line.starts_with("@@ ") {
+                    anyhow::bail!(
+                        "Invalid UTF-8: {} \"{}\"",
+                        line.len(),
+                        buffer.to_lossy_string()
+                    );
+                } else {
+                    warn!(
+                        "Invalid UTF-8: {} \"{}\"",
+                        line.len(),
+                        buffer.to_lossy_string()
+                    );
+                }
+            }
+            if let Some(captures) = re_file.captures(line) {
+                if is_path_found {
+                    if let Err(error) = child.kill() {
+                        warn!("Stopping child: {error}");
+                    }
+                    break;
+                }
+                is_in_hunk = false;
+                let new_path = captures.get(2).unwrap().as_str();
+                is_path_found = new_path == path;
+                if !is_path_found {
+                    // trace!("file: {new_path:?}, not interesting");
+                    continue;
+                }
+                let old_path_from_git = captures.get(1).unwrap().as_str();
+                if old_path_from_git != path {
+                    old_path = Some(old_path_from_git.into());
+                }
+                trace!("file: found {new_path:?} old={old_path:?} {old_path_from_git}");
+                continue;
+            }
+            if !is_path_found {
+                continue;
+            }
+            if let Some(captures) = re_hunk.captures(line) {
+                let old_line_number = captures.get(1).unwrap().as_str().parse::<usize>()?;
+                let new_line_number = captures.get(3).unwrap().as_str().parse::<usize>()?;
+                context.on_git_hunk(old_line_number, new_line_number);
+                is_in_hunk = true;
+                continue;
+            }
+            if is_in_hunk {
+                context.on_git_line(line);
+            }
+        }
+        context.flush_part();
+
+        self.old_path = old_path;
+        self.diff_parts = context.parts;
+        debug!("read_by_git.done: elapsed {:?}", start_time.elapsed());
+        trace!("read_by_git.result={self:#?}");
+
+        let exit_status = child.wait()?;
+        trace!(
+            "read_by_git.exit: {exit_status}, elapsed {:?}",
+            start_time.elapsed()
+        );
+        Ok(())
+    }
+
+    fn read_by_git2(&mut self, git: &GitTools) -> anyhow::Result<()> {
+        let start_time = std::time::Instant::now();
+        let commit_id = self.commit_id;
+        debug!("read_by_git2.start: {commit_id:?} {:?}", self.path);
         let commit = git.repository().find_commit(commit_id)?;
         self.set_commit(&commit);
 
@@ -91,7 +205,8 @@ impl FileCommit {
         let tree = commit.tree()?;
         let parent_tree = parent.tree()?;
         trace!(
-            "tree {}..{}: elapsed {:?}",
+            "parent={}, tree={}..{}: elapsed {:?}",
+            parent.id(),
             parent_tree.id(),
             tree.id(),
             start_time.elapsed()
@@ -166,13 +281,8 @@ impl FileCommit {
             }
         }
         self.diff_parts = context.parts;
-        DiffPart::validate_ascending_parts(&self.diff_parts).unwrap();
-        trace!(
-            "read diff for commit_id: {:?} done, elapsed {:?}",
-            self.commit_id,
-            start_time.elapsed()
-        );
-        trace!("{self:#?}");
+        debug!("read_by_git2.done: elapsed {:?}", start_time.elapsed());
+        trace!("read_by_git2.result={self:#?}");
         Ok(())
     }
 
@@ -231,11 +341,44 @@ impl DiffReadContext {
                 assert_eq!(num_lines, 1);
                 self.part.old.add_line(old_line_number.unwrap() as usize);
             }
-            '<' => {},
+            '<' => {}
             _ => {
                 debug!("origin {:?} skipped", origin);
             }
         }
+    }
+
+    fn on_git_hunk(&mut self, old_line_number: usize, new_line_number: usize) {
+        trace!("on_git_hunk: {old_line_number},{new_line_number}");
+        self.old_line_number = old_line_number;
+        self.new_line_number = new_line_number;
+    }
+
+    fn on_git_line(&mut self, line: &str) {
+        let origin = line.as_bytes().first().map_or('\0', |b| *b as char);
+        trace!(
+            "on_git_line: {origin} {},{}",
+            self.old_line_number, self.new_line_number
+        );
+        match origin {
+            ' ' => {
+                self.flush_part();
+                self.old_line_number += 1;
+                self.new_line_number += 1;
+            }
+            '+' => {
+                self.part.new.add_line(self.new_line_number);
+                self.new_line_number += 1;
+            }
+            '-' => {
+                self.part.old.add_line(self.old_line_number);
+                self.old_line_number += 1;
+            }
+            // "\ No newline at end of file"
+            '\\' => {}
+            _ => unreachable!("Unexpected line: \"{line}\""),
+        }
+        trace!("on_git_line: done: {:?} {:?}", self.part.old, self.part.new);
     }
 
     fn flush_part(&mut self) {
@@ -297,7 +440,13 @@ mod tests {
 
         let mut file_commit = FileCommit::new(commit_id3, path);
         file_commit.read(&git.git)?;
-        assert_eq!(file_commit.diff_parts, []);
+        match FileCommit::git_engine() {
+            GitEngine::Git => {
+                assert_eq!(file_commit.diff_parts, [DiffPart::from_ranges(5..6, 5..6)])
+            }
+            // `git2` can't report changes in the newline at end.
+            GitEngine::Git2 => assert_eq!(file_commit.diff_parts, []),
+        }
         assert_eq!(file_commit.old_path_if_rename(), None);
         Ok(())
     }

--- a/src/blame/git_diff_line.rs
+++ b/src/blame/git_diff_line.rs
@@ -1,0 +1,58 @@
+use std::{
+    borrow::Cow,
+    io::{self, BufRead},
+};
+
+#[derive(Debug)]
+pub struct GitDiffLine<R: BufRead> {
+    buffer: Vec<u8>,
+    valid_len: usize,
+    invalid_len: usize,
+    inner: R,
+}
+
+impl<R: BufRead> GitDiffLine<R> {
+    pub fn new(inner: R) -> Self {
+        Self {
+            buffer: vec![],
+            valid_len: 0,
+            invalid_len: 0,
+            inner,
+        }
+    }
+
+    pub fn invalid_len(&self) -> usize {
+        self.invalid_len
+    }
+
+    pub fn as_str(&self) -> &str {
+        unsafe { std::str::from_utf8_unchecked(&self.buffer[..self.valid_len]) }
+    }
+
+    pub fn to_lossy_string(&self) -> Cow<'_, str> {
+        String::from_utf8_lossy(&self.buffer[..self.valid_len])
+    }
+
+    pub fn next_line(&mut self) -> io::Result<bool> {
+        self.buffer.clear();
+        let mut len = self.inner.read_until(b'\n', &mut self.buffer)?;
+        if len == 0 {
+            return Ok(false);
+        }
+
+        if len > 0 && self.buffer[len - 1] == b'\n' {
+            len -= 1;
+        }
+        match std::str::from_utf8(&self.buffer[..len]) {
+            Ok(s) => {
+                self.valid_len = s.len();
+                self.invalid_len = 0;
+            }
+            Err(error) => {
+                self.valid_len = error.valid_up_to();
+                self.invalid_len = len - self.valid_len;
+            }
+        }
+        Ok(true)
+    }
+}

--- a/src/blame/mod.rs
+++ b/src/blame/mod.rs
@@ -13,6 +13,9 @@ pub use file_commit::*;
 mod file_content;
 pub use file_content::*;
 
+mod git_diff_line;
+pub use git_diff_line::*;
+
 mod file_history;
 pub use file_history::*;
 

--- a/src/ui/cli.rs
+++ b/src/ui/cli.rs
@@ -17,6 +17,10 @@ use super::*;
 #[derive(Debug, Default, Parser)]
 #[command(version, about)]
 struct Args {
+    /// Use git2 to compute the commit diff.
+    #[arg(long, default_value_t = false)]
+    diff_git2: bool,
+
     /// Path of the file to annotate the history.
     path: PathBuf,
 }
@@ -43,6 +47,9 @@ pub struct Cli {
 impl Cli {
     pub fn new_from_args() -> Self {
         let args = Args::parse();
+        if args.diff_git2 {
+            crate::blame::FileCommit::use_git2();
+        }
         Self {
             path: args.path,
             ..Default::default()


### PR DESCRIPTION
It turned out that there are cases where git2 is slow and
fails to detect renames.

This patch switches the logic to using `git` as a child
process.

Also add an option to use git2 as the engine.

Fixes #92 and #93.
