### PR TITLE
Repaint scrolls the current line to the center of the view

### DIFF
--- a/src/ui/blame_renderer.rs
+++ b/src/ui/blame_renderer.rs
@@ -1,4 +1,4 @@
-use std::{io::Write, ops::Range, path::Path};
+use std::{cmp, io::Write, ops::Range, path::Path};
 
 use anyhow::bail;
 use crossterm::{cursor, queue, terminal};
@@ -165,6 +165,19 @@ impl BlameRenderer {
         if self.view_start_line_index < below_margin_start_index {
             self.view_start_line_index = below_margin_start_index;
         }
+    }
+
+    pub fn scroll_current_line_to_center_of_view(&mut self) {
+        let view_rows = self.view_rows() as usize;
+        let view_rows_half = view_rows / 2;
+        let line_index = self.current_line_index();
+        if line_index < view_rows_half {
+            self.view_start_line_index = 0;
+            return;
+        }
+        let max_view_start_line_index = self.content.lines_len() - view_rows;
+        self.view_start_line_index =
+            cmp::min(line_index - view_rows_half, max_view_start_line_index);
     }
 
     pub fn commit_id(&self) -> Oid {

--- a/src/ui/cli.rs
+++ b/src/ui/cli.rs
@@ -187,7 +187,10 @@ impl Cli {
                 CommandUI::wait_for_any_key("Press any key to continue...")?;
             }
             Command::Timeout => renderer.read_poll()?,
-            Command::Repaint => renderer.invalidate_render(),
+            Command::Repaint => {
+                renderer.invalidate_render();
+                renderer.scroll_current_line_to_center_of_view();
+            }
             Command::Resize(columns, rows) => renderer.set_view_size((columns, rows - 1)),
             Command::Debug => {
                 let commit_id = renderer.current_line_commit_id()?;


### PR DESCRIPTION
The `Repaint` command (`r`, `^L`, `^R`) scrolls so that the current line appears in the center of the view, the same way as Emacs.

Fixes #120.
