### PR TITLE
Add `rust-version = "1.89"` to `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "git-iblame"
 version = "0.8.4"
 edition = "2024"
+rust-version = "1.89"
 authors = ["Koji Ishii <kojiishi@gmail.com>"]
 description = "Interactive enhanced `git blame` command line tool."
 keywords = ["git", "blame", "command", "command-line-tool", "cli"]


### PR DESCRIPTION
Because the PR #113 causes the build error for older versions than 1.89.
