### PR TITLE
Change flie deletions in the history from crash to error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "git-iblame"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-iblame"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Koji Ishii <kojiishi@gmail.com>"]


### PR DESCRIPTION
This patch changes `insert_deleted_part` to raise an error for a full deletion instead of an assertion failure.

This is still unexpected, most likely a broken history, but it may happen. See #127 and #131.
