### PR TITLE
Add `BlameError`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,6 +333,7 @@ dependencies = [
  "log",
  "regex",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]
@@ -885,6 +886,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ env_logger = "0.11.8"
 git2 = { version = "0.20.2", default-features = false }
 log = "0.4.28"
 regex = "1.11.2"
+thiserror = "2.0.16"
 
 [dev-dependencies]
 tempfile = "3.22.0"

--- a/src/blame/blame_error.rs
+++ b/src/blame/blame_error.rs
@@ -1,0 +1,5 @@
+#[derive(thiserror::Error, Debug)]
+pub enum BlameError {
+    #[error("The file was deleted at {0:?}")]
+    FileDeleted(git2::Oid),
+}

--- a/src/blame/file_content.rs
+++ b/src/blame/file_content.rs
@@ -8,7 +8,7 @@ use log::*;
 
 use crate::extensions::GitTools;
 
-use super::{DiffPart, FileCommit, FileHistory, Line, LineNumberMap};
+use super::{BlameError, DiffPart, FileCommit, FileHistory, Line, LineNumberMap};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ContentType {
@@ -341,7 +341,7 @@ impl FileContent {
         let new_line_numbers = part.new.line_numbers();
         assert!(new_line_numbers.is_empty());
         if new_line_numbers.start == 0 {
-            anyhow::bail!("The file was deleted at {commit_id:?}");
+            return Err(BlameError::FileDeleted(commit_id).into());
         }
         let old_line_numbers = &part.old.line_numbers;
         assert!(old_line_numbers.start > 0);

--- a/src/blame/mod.rs
+++ b/src/blame/mod.rs
@@ -1,3 +1,6 @@
+mod blame_error;
+pub use blame_error::*;
+
 mod commit_iterator;
 pub use commit_iterator::*;
 


### PR DESCRIPTION
To distinguish flie-deleted error from other errors.

This is a preparation to improve #131.
