### PR TITLE
ci: Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,9 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      dependencies:
+        patterns:
+          - '*'


### PR DESCRIPTION
Add [`groups`] to the `dependabot.yml` to bulk update multiple dependencies.

[`groups`]: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--
