### PR TITLE
fix: diff file names surrounded by double quotes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "git-iblame"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-iblame"
-version = "0.8.9"
+version = "0.8.10"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Koji Ishii <kojiishi@gmail.com>"]

--- a/src/blame/file_commit.rs
+++ b/src/blame/file_commit.rs
@@ -122,7 +122,7 @@ impl FileCommit {
         let stdout = child.stdout.take().unwrap();
         let mut reader = BufReader::new(stdout);
         let mut buffer = LineReadBuffer::new();
-        let re_file = Regex::new(r"^diff --git a/(.+) b/(.+)$")?;
+        let re_file = Regex::new(r#"^diff --git "?a/(.+?)"? "?b/(.+?)"?$"#)?;
         let re_hunk = Regex::new(r"^@@ -(\d+),(\d+) \+(\d+),(\d+) @@")?;
 
         let path = self.path.to_str().unwrap();
@@ -356,6 +356,7 @@ impl DiffReadContext {
     }
 
     fn on_git_line(&mut self, line: &str) {
+        trace!("on_git_line: line={line:?}");
         let origin = line.as_bytes().first().map_or('\0', |b| *b as char);
         trace!(
             "on_git_line: {origin} {},{}",


### PR DESCRIPTION
In the `git diff` output, file names in the `diff` line could
be surrounded by double quotes. For example:
```
diff --git "a/css-inline-3/images/Initial-2line-JapaneseVertical\345\205\255.png" b/css-inline-3/images/Initial-2line-JapaneseVertical.png
```

Fixes #175.
