### PR TITLE
build(deps): bump git2 from 0.20.4 to 0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,17 +241,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "document-features"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,15 +289,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "git-iblame"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -340,22 +320,21 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags",
  "libc",
  "libgit2-sys",
  "log",
- "url",
 ]
 
 [[package]]
 name = "git2-time-chrono-ext"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a268b7ad871f943b6ae39f0ea8a949d3fd5c43554d5627f0c30cc22139582414"
+checksum = "626a5926cbf4d1579a4f4f6bb8fb11a11733b7602fbe6977f290dac8106715c3"
 dependencies = [
  "chrono",
  "git2",
@@ -390,113 +369,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "icu_collections"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
-
-[[package]]
-name = "icu_properties"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "potential_utf",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
-
-[[package]]
-name = "icu_provider"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "idna"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
 ]
 
 [[package]]
@@ -557,9 +429,9 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.4+1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
 dependencies = [
  "cc",
  "libc",
@@ -584,12 +456,6 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
-name = "litemap"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "litrs"
@@ -670,12 +536,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "percent-encoding"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,15 +554,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
-]
-
-[[package]]
-name = "potential_utf"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
-dependencies = [
- "zerovec",
 ]
 
 [[package]]
@@ -793,15 +644,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "serde"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,12 +706,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,17 +720,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -931,16 +756,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,23 +772,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "url"
-version = "2.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
-]
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1236,88 +1034,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "writeable"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
-
-[[package]]
-name = "yoke"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerotrie"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-iblame"
-version = "0.9.4"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Koji Ishii <kojiishi@gmail.com>"]
@@ -17,8 +17,8 @@ chrono = "0.4.44"
 clap = { version = "4.6.1", features = ["derive"] }
 crossterm = { version = "0.29.0", features = ["osc52"] }
 env_logger = "0.11.10"
-git2 = { version = "0.20.4", default-features = false }
-git2-time-chrono-ext = "1.0.0"
+git2 = { version = "0.21.0", default-features = false }
+git2-time-chrono-ext = "1.0.1"
 log = "0.4.29"
 regex = "1.12.3"
 thiserror = "2.0.18"

--- a/src/blame/file_commit.rs
+++ b/src/blame/file_commit.rs
@@ -29,7 +29,7 @@ pub struct FileCommit {
     index: usize,
     time: git2::Time,
     summary: Option<String>,
-    author_email: Option<String>,
+    author_email: String,
     old_path: Option<PathBuf>,
     diff_parts: Vec<DiffPart>,
     is_apply_failed: AtomicBool,
@@ -43,7 +43,7 @@ impl FileCommit {
             index: 0,
             time: git2::Time::new(0, 0),
             summary: None,
-            author_email: None,
+            author_email: String::default(),
             old_path: None,
             diff_parts: Vec::new(),
             is_apply_failed: AtomicBool::new(false),
@@ -82,7 +82,7 @@ impl FileCommit {
         self.summary.as_ref()
     }
 
-    pub fn author_email(&self) -> Option<&String> {
+    pub fn author_email(&self) -> &str {
         self.author_email.as_ref()
     }
 
@@ -127,7 +127,7 @@ impl FileCommit {
         let commit_id = self.commit_id;
         debug!("read_by_git.start: {commit_id:?} {:?}", self.path);
         let commit = git.repository().find_commit(commit_id)?;
-        self.set_commit(&commit);
+        self.set_commit(&commit)?;
 
         let mut paths: Vec<&Path> = vec![];
         if !check_rename {
@@ -222,7 +222,7 @@ impl FileCommit {
         let commit_id = self.commit_id;
         debug!("read_by_git2.start: {commit_id:?} {:?}", self.path);
         let commit = git.repository().find_commit(commit_id)?;
-        self.set_commit(&commit);
+        self.set_commit(&commit)?;
 
         let parent = commit.parent(0);
         if parent.is_err() {
@@ -337,10 +337,11 @@ impl FileCommit {
         Ok(())
     }
 
-    fn set_commit(&mut self, commit: &git2::Commit) {
+    fn set_commit(&mut self, commit: &git2::Commit) -> Result<(), git2::Error> {
         self.time = commit.time();
-        self.summary = commit.summary().map(|s| s.to_string());
-        self.author_email = commit.author().email().map(|s| s.to_string());
+        self.summary = commit.summary()?.map(|s| s.to_string());
+        self.author_email = commit.author().email()?.to_string();
+        Ok(())
     }
 }
 
@@ -457,7 +458,7 @@ mod tests {
         let git = TempRepository::new()?;
         let path = Path::new("text.txt");
         git.add_file_content(path, "1\n2\n3\n4\n5\n")?;
-        let commit_id1 = git.commit(git2::Oid::zero(), "Add file")?;
+        let commit_id1 = git.commit(git2::Oid::ZERO_SHA1, "Add file")?;
 
         git.add_file_content(path, "1\n2\nX\nY\nZ\n4\n5\n")?;
         let commit_id2 = git.commit(commit_id1, "Rename file")?;
@@ -474,7 +475,7 @@ mod tests {
         // Create a dummy initial commit to avoid "no parent" code path.
         let git = TempRepository::new()?;
         git.add_file_content(Path::new("initial.txt"), "initial")?;
-        let commit_id1 = git.commit(git2::Oid::zero(), "Initial")?;
+        let commit_id1 = git.commit(git2::Oid::ZERO_SHA1, "Initial")?;
 
         // Note no new line at end of file.
         let path = Path::new("test.txt");
@@ -509,7 +510,7 @@ mod tests {
         let old_path = Path::new("old.txt");
         let new_path = Path::new("new.txt");
         git.add_file_content(old_path, "content")?;
-        let commit_id1 = git.commit(git2::Oid::zero(), "Add file")?;
+        let commit_id1 = git.commit(git2::Oid::ZERO_SHA1, "Add file")?;
 
         git.rename_file(old_path, new_path)?;
         let commit_id2 = git.commit(commit_id1, "Rename file")?;

--- a/src/blame/file_content.rs
+++ b/src/blame/file_content.rs
@@ -50,7 +50,7 @@ impl FileContent {
 
     #[cfg(test)]
     pub fn new_for_test() -> Self {
-        Self::new(git2::Oid::zero(), Path::new(""))
+        Self::new(git2::Oid::ZERO_SHA1, Path::new(""))
     }
 
     pub fn content_type(&self) -> ContentType {

--- a/src/blame/line.rs
+++ b/src/blame/line.rs
@@ -167,13 +167,13 @@ impl Line {
                             format!("#{} {}", commit.index(), datetime)
                         }
                         LineType::Log => {
-                            format!("{} {}", datetime, commit.author_email().or_default())
+                            format!("{} {}", datetime, commit.author_email())
                         }
                     }
                     .into()
                 }
                 1 => commit.summary().map(|s| format!("  {s}")).or_default(),
-                2 => commit.author_email().map(|s| format!("  {s}")).or_default(),
+                2 => format!("  {}", commit.author_email()).into(),
                 3 => format!("  {}", commit.commit_id()).into(),
                 _ => "".into(),
             }

--- a/src/extensions/git_tools.rs
+++ b/src/extensions/git_tools.rs
@@ -262,9 +262,9 @@ pub(crate) mod tests {
         let path = PathBuf::from("test.txt");
         let content = "Hello, world!";
         git.add_file_content(&path, content)?;
-        git.commit(git2::Oid::zero(), "Add file")?;
+        git.commit(git2::Oid::ZERO_SHA1, "Add file")?;
         assert_eq!(
-            git.git.content_as_string(git2::Oid::zero(), &path)?,
+            git.git.content_as_string(git2::Oid::ZERO_SHA1, &path)?,
             content
         );
         Ok(())

--- a/src/ui/blame_renderer.rs
+++ b/src/ui/blame_renderer.rs
@@ -22,7 +22,7 @@ pub struct BlameRenderer {
 
 impl BlameRenderer {
     pub fn new(history: FileHistory) -> anyhow::Result<Self> {
-        let content = history.content(git2::Oid::zero())?;
+        let content = history.content(git2::Oid::ZERO_SHA1)?;
         Ok(Self {
             history,
             content,
@@ -276,7 +276,7 @@ impl BlameRenderer {
         if self.content.content_type() == ContentType::Log {
             return Ok(());
         }
-        let mut content = FileContent::new_log(git2::Oid::zero(), self.path());
+        let mut content = FileContent::new_log(git2::Oid::ZERO_SHA1, self.path());
         content.update_commits(&self.history)?;
         if content.lines_len() == 0 {
             anyhow::bail!("No commits loaded yet")


### PR DESCRIPTION
Bumped to v0.10.0 to support changes in `git2` 0.21.0 ([Changelog](https://github.com/rust-lang/git2-rs/blob/main/CHANGELOG.md)).

Includes `git2-time-chrono-ext` to 1.0.1, which supports `git2` 0.21.0.
